### PR TITLE
Ignore Eclipse project files (mvn eclipse:eclipse)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,8 @@ buildNumber.properties
 
 /.idea/
 *.iml
+
+# Eclipse
+/.project
+/.classpath
+/.settings


### PR DESCRIPTION
When working on the project with Eclipse, some more files should be ignored from git